### PR TITLE
feat: Updated the Discord Invite Link

### DIFF
--- a/src/lib/footer/Footer.svelte
+++ b/src/lib/footer/Footer.svelte
@@ -6,7 +6,7 @@
       class: 'btn twitter'
     },
     {
-      href: 'https://discord.com/invite/UQmbKjjgeb',
+      href: 'https://katb.in/gdgchennai-discord',
       icon: 'fa fa-discord',
       class: 'btn discord'
     },


### PR DESCRIPTION
I have Changed the Old Discord Invite link which was pointing to an individual account to the invite link that is pointed from GDG's Account